### PR TITLE
Make read and scan clearer

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -42,8 +42,10 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.floraKit.delegate = self
-        self.floraKit.readAll()
-        
+        self.floraKit.scan { (uuids) in
+            self.numberOfDevices = uuids.count
+            self.floraKit.read(uuids: uuids)
+        }        
         self.view.addSubview(self.tableView)
         self.view.addSubview(self.activityIndicator)
         
@@ -86,11 +88,6 @@ extension ViewController: UITableViewDataSource {
 extension ViewController: FloraKitDelegate {
     func floraKit(_ floraKit: FloraKit, stateChanged state: FloraServiceState) {
         switch state {
-        case .beginScan:
-            print("Begin Scan")
-        case .endScan(let deviceIds):
-            self.numberOfDevices = deviceIds.count
-            print("Scan complete, found \(self.numberOfDevices)")
         case .deviceConnected(let name, let uuid):
             print("Connected to \(name ?? "") \(uuid.uuidString)")
         case .recievedSensorData(let sensorData):

--- a/Sources/FloraKit.swift
+++ b/Sources/FloraKit.swift
@@ -15,29 +15,22 @@ public protocol FloraKitDelegate: class {
 
 /// This class is only a wrapper class around FloraService to avoid exposing unecessary delegate methods
 public class FloraKit: NSObject {
+    public static let defaultScanDuration: Int = FloraService.defaultScanDuration
+    public static let defaultReadTimeout: Int = FloraService.defaultReadTimeout
     private let floraService: FloraService = FloraService()
     public weak var delegate: FloraKitDelegate?
     
-    convenience override public init() {
-        self.init(scanDuration: nil)
-    }
-    
-    public init(scanDuration: Int?) {
+    public override init() {
         super.init()
-        self.floraService.scanDuration = scanDuration ?? FloraService.defaultScanDuration
         self.floraService.delegate = self
     }
     
-    public func scan(completion: @escaping (_ floraDevices: [UUID]) -> Void) {
-        self.floraService.scan(completion: completion)
+    public func scan(withDuration duration: Int = FloraKit.defaultScanDuration, completion: @escaping (_ floraDevices: [UUID]) -> Void) {
+        self.floraService.scan(withDuration: duration, completion: completion)
     }
     
-    public func read(uuids: [UUID]) {
-        self.floraService.read(uuids: uuids)
-    }
-
-    public func readAll() {
-        self.floraService.readAll()
+    public func read(withTimeout timeout: Int = FloraKit.defaultReadTimeout, uuids: [UUID]) {
+        self.floraService.read(withTimeout: timeout, uuids: uuids)
     }
 }
 


### PR DESCRIPTION
It was not really clear, that readAll does also a scan and why there is a scan function with a completion handler.
So if you don´t have device uuids you have to explicit do a scan before, that should make the programm flow much clearer.